### PR TITLE
BUGFIX: blog name was breaking the tag rss

### DIFF
--- a/code/DataExtensions/EnhancedBlogTree.php
+++ b/code/DataExtensions/EnhancedBlogTree.php
@@ -16,11 +16,14 @@ class BlogTreeControllerExtension extends DataExtension {
 	);
 	
 	function tag() {
+		
+		$blogName = $this->owner->Title . " - " . ucwords($this->owner->request->latestParam('ID')); 
+		
 		if ($this->owner->request->param('Action') == 'tag' && $this->owner->request->param('OtherID') == "rss") {
 			$entries = $this->owner->Entries(20, Convert::raw2xml($this->owner->request->latestParam('ID')));
 			
 			if($entries) {
-				$rss = new RSSFeed($entries, $this->owner->Link('rss'), ($blogName ? $blogName : $altBlogName), "", "Title", "RSSContent");
+				$rss = new RSSFeed($entries, $this->owner->Link('rss'), $blogName, "", "Title", "RSSContent");
 				return $rss->outputToBrowser();
 				
 			}


### PR DESCRIPTION
Latest version of blog module only uses $Title.

This corrects the bug and adds a reference to the rss feed's tag in the rss <title>.
