### PR TITLE
FIX Track the 1.0 branch of blog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	"require":
 	{
 		"silverstripe/cms": "~3.1",
-		"silverstripe/blog": "dev-master"
+		"silverstripe/blog": "~1.0"
 	},
 	"config": {
 		"process-timeout": 600	


### PR DESCRIPTION
This is due to master of silverstripe/blog now being a major version rewrite to 2.0