### PR TITLE
Updated as this works on blog 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	"require":
 	{
 		"silverstripe/cms": "~3.1",
-		"silverstripe/blog": "dev-master"
+		"silverstripe/blog": "~1.0"
 	},
 	"config": {
 		"process-timeout": 600	


### PR DESCRIPTION
new blog 2.0 already has a lot of this functionality so doesn't make sense to use this on 2.0. Still lots of 1.0 blog users find this a useful module.